### PR TITLE
reorder the languages menu alphabitically

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -31,12 +31,12 @@ bool materialColor = false;
 Locale locale = const Locale('en', 'US');
 
 final List appLanguages = [
+  {'name': 'العربية', 'locale': const Locale('ar', 'AR')},
   {'name': 'English', 'locale': const Locale('en', 'US')},
+  {'name': 'فارسی', 'locale': const Locale('fa', 'IR')},
   {'name': 'Русский', 'locale': const Locale('ru', 'RU')},
   {'name': '中文', 'locale': const Locale('zh', 'CN')},
   {'name': '中国传统台湾', 'locale': const Locale('zh', 'TW')},
-  {'name': 'فارسی', 'locale': const Locale('fa', 'IR')},
-  {'name': 'العربية', 'locale': const Locale('ar', 'AR')},
 ];
 
 void main() async {


### PR DESCRIPTION
reorder the languages menu in the settings so that the languages are ordered alphabetically.

most people will find their language faster because every other app uses alphabetical order for languages.