### PR TITLE
fix(lang-settings): resolve issue in language dialog

### DIFF
--- a/lib/app/ui/settings/view/settings.dart
+++ b/lib/app/ui/settings/view/settings.dart
@@ -453,7 +453,12 @@ class _SettingsPageState extends State<SettingsPage> {
       icon: IconsaxPlusBold.language_square,
       items: appLanguages,
       currentValue: appLanguages.firstWhere(
-        (element) => element['locale'] == locale,
+        (element) =>
+            (element['locale'] as Locale).languageCode == locale.languageCode,
+        orElse: () => <String, dynamic>{
+          'name': 'English',
+          'locale': const Locale('en', 'US'),
+        },
       ),
       itemBuilder: (lang) => lang['name'] as String,
       onSelected: (value) {


### PR DESCRIPTION
The dialog was failing to open because firstWhere comparison was done via equality, since getx is being used it is not reliable to use equality since some internal mutations can be done thus equality fails even though locale is const

fixed by using .languageCode and added a fallback to give locale (en,us) as default.


[Ref]
Error Encountered -> Another exception was thrown: Bad state: No element 
Reason -> Nothing matches the equality & no fallback (orElse) was given 
