### PR TITLE
fix: setState Assertion Error in Calendar View

### DIFF
--- a/lib/app/ui/todos/view/calendar_todos.dart
+++ b/lib/app/ui/todos/view/calendar_todos.dart
@@ -228,8 +228,10 @@ class _CalendarTodosState extends State<CalendarTodos>
             ),
           ),
           onDaySelected: _onDaySelected,
-          onFormatChanged: (format) =>
-              setState(() => _updateCalendarFormat(format)),
+          onFormatChanged: (format) {
+            _updateCalendarFormat(format);
+            setState(() {});
+          },
           onPageChanged: (focusedDay) {
             _focusedDay = focusedDay;
           },
@@ -282,18 +284,18 @@ class _CalendarTodosState extends State<CalendarTodos>
   }
 
   Future<void> _updateCalendarFormat(CalendarFormat format) async {
+    switch (format) {
+      case CalendarFormat.week:
+        settings.calendarFormat = 'week';
+        break;
+      case CalendarFormat.twoWeeks:
+        settings.calendarFormat = 'twoWeeks';
+        break;
+      case CalendarFormat.month:
+        settings.calendarFormat = 'month';
+        break;
+    }
     await isar.writeTxn(() async {
-      switch (format) {
-        case CalendarFormat.week:
-          settings.calendarFormat = 'week';
-          break;
-        case CalendarFormat.twoWeeks:
-          settings.calendarFormat = 'twoWeeks';
-          break;
-        case CalendarFormat.month:
-          settings.calendarFormat = 'month';
-          break;
-      }
       await isar.settings.put(settings);
     });
   }


### PR DESCRIPTION
bug:
setState accepts a sync callback, but here it was a async callback - so flutter will ping it as a assertion error
[so basically clicking the chip will not perform anything]

> log: Another exception was thrown: setState() callback argument returned a Future. 

fix:
- called the async func before hand & and then used setState to revalidate for the next build 
- plus moved the switch case outside of the async - so we can have a optimistic ui update - while the func takes its time to write to isar